### PR TITLE
ACSIS: Handle an undefined RECIPE header.

### DIFF
--- a/lib/Astro/FITS/HdrTrans/ACSIS.pm
+++ b/lib/Astro/FITS/HdrTrans/ACSIS.pm
@@ -138,8 +138,9 @@ these are many-to-many)
 
 =item B<to_DR_RECIPE>
 
-Usually simply copies the "RECIPE" header. If the observation type is
-skydip and the RECIPE header is "REDUCE_SCIENCE" we actually use
+Usually simply copies the RECIPE header. If the header is undefined,
+initially set the recipe to REDUCE_SCIENCE. If the observation type
+is skydip and the RECIPE header is "REDUCE_SCIENCE", actually use
 REDUCE_SKYDIP. If a skydip is not being done and the STANDARD header
 is true, then the recipe is set to REDUCE_STANDARD. If the INBEAM
 header is "POL", the recipe name has "_POL" appended if it is a
@@ -153,6 +154,11 @@ sub to_DR_RECIPE {
   my $FITS_headers = shift;
 
   my $dr = $FITS_headers->{RECIPE};
+  if ( defined( $dr ) ) {
+     $dr = uc( $dr );
+  } else {
+     $dr = 'REDUCE_SCIENCE';
+  }
 
   my $obstype = lc( $class->to_OBSERVATION_TYPE( $FITS_headers ) );
   my $pol = $class->to_POLARIMETER( $FITS_headers );
@@ -176,8 +182,8 @@ sub to_DR_RECIPE {
   if ( $utdate > 20081115 && $pol && $is_sci ) {
     $dr .= "_POL" unless $dr =~ /_POL$/;
   }
-  $dr = uc($dr);
-  if( $dr eq 'REDUCE_SCIENCE' ) {
+
+  if ( $dr eq 'REDUCE_SCIENCE' ) {
     $dr .= '_' . ($freq_sw ? 'FSW' : 'GRADIENT');
   }
 


### PR DESCRIPTION
There was some vintage data that did not have the reduction recipe
defined, causing errors when an attempt was made to convert the recipe
to uppercase.  Default to REDUCE_SCIENCE in this case.

Revised the pod description accordingly and also used consistent
quoting.